### PR TITLE
アイテム一覧画面で選択したデータが取得できないときがある問題を修正

### DIFF
--- a/app/src/main/java/com/ishzk/android/recieptchart/component/SelectYearMonthView.kt
+++ b/app/src/main/java/com/ishzk/android/recieptchart/component/SelectYearMonthView.kt
@@ -15,8 +15,9 @@ class SelectYearMonthView : LinearLayout {
     private val binding by lazy { ViewSelectyearmonthBinding.inflate(LayoutInflater.from(context), this, true) }
     val selectedYear by lazy { MutableLiveData<Int>() }
     val selectedMonth by lazy { MutableLiveData<Int>() }
-    val selectedDate: Date
+    private val _selectedDate: Date
         get() = Date((selectedYear.value ?: 2022) - 1900, (selectedMonth.value ?: 1) - 1, 1)
+    val selectedDate by lazy { MutableLiveData<Date>() }
 
     init {
         binding.nextMonthButton.setOnClickListener{
@@ -25,6 +26,8 @@ class SelectYearMonthView : LinearLayout {
 
             selectedMonth.value = if(currentMonth == 12) 1 else currentMonth + 1
             selectedYear.value = if(currentMonth == 12) currentYear + 1 else currentYear
+
+            selectedDate.value = _selectedDate
 
             binding.selectedYearMonthText.text = "${selectedYear.value}/${(selectedMonth.value ?: 1)}"
         }
@@ -35,6 +38,8 @@ class SelectYearMonthView : LinearLayout {
 
             selectedMonth.value = if(currentMonth == 1) 12 else currentMonth - 1
             selectedYear.value = if(currentMonth == 1) currentYear - 1 else currentYear
+
+            selectedDate.value = _selectedDate
 
             binding.selectedYearMonthText.text = "${selectedYear.value}/${(selectedMonth.value ?: 1)}"
         }

--- a/app/src/main/java/com/ishzk/android/recieptchart/fragment/HouseholdFragment.kt
+++ b/app/src/main/java/com/ishzk/android/recieptchart/fragment/HouseholdFragment.kt
@@ -63,6 +63,7 @@ class HouseholdFragment: Fragment() {
             val today = Date()
             selectedYear.value = today.year + 1900
             selectedMonth.value = today.month + 1
+            selectedDate.value = today
         }
 
         return binding.root
@@ -72,12 +73,12 @@ class HouseholdFragment: Fragment() {
         super.onViewCreated(view, savedInstanceState)
 
         // fetch items on recycler view.
-        binding.selectYearMonth.selectedMonth.observe(viewLifecycleOwner){
+        binding.selectYearMonth.selectedDate.observe(viewLifecycleOwner){
             viewLifecycleOwner.lifecycleScope.launch {
                 viewModel.isFetching.value = true
 
-                viewModel.fetchMonthlyItems(binding.selectYearMonth.selectedDate).collect{
-                    Log.d(TAG, "Fetch date: ${binding.selectYearMonth.selectedDate}")
+                viewModel.fetchMonthlyItems(it).collect{
+                    Log.d(TAG, "Fetch date: $it")
                     listAdapter.submitList(it)
                 }
 


### PR DESCRIPTION
#20 
選択した年月を変更したときに通知される年月が、選択した年月と異なっていたため、
想定したデータを取得できていなかった。