### PR TITLE
レシート画像をストレージから読み取り、認識する

### DIFF
--- a/app/src/main/java/com/ishzk/android/recieptchart/viewmodel/ReceiptCameraViewModel.kt
+++ b/app/src/main/java/com/ishzk/android/recieptchart/viewmodel/ReceiptCameraViewModel.kt
@@ -20,6 +20,7 @@ class ReceiptCameraViewModel(application: Application) : AndroidViewModel(applic
     val cameraOutputOptions = MutableLiveData<ImageCapture.OutputFileOptions>()
     val takenPictureUri = MutableLiveData<Uri>()
     val isTakingPicture = MutableLiveData(false)
+    val pushedPickButton = MutableLiveData(false)
 
     fun captureReceipt(){
         Log.d(TAG, "Capture button is touched.")
@@ -43,6 +44,7 @@ class ReceiptCameraViewModel(application: Application) : AndroidViewModel(applic
 
     fun pickImageFile(){
         Log.d(TAG, "Select image floating button is pushed.")
+        pushedPickButton.postValue(true)
     }
 
     val saveImageCallback = object : ImageCapture.OnImageSavedCallback{


### PR DESCRIPTION
#24 フローティングボタン押下時に、ストレージ選択画面を表示
選択した画像のuri取得後はカメラによる画像撮影と同じ処理を行っている