### PR TITLE
同じ日付の支出が別の日付カードとして一覧に表示される問題を修正

### DIFF
--- a/app/src/main/java/com/ishzk/android/recieptchart/fragment/HouseholdFragment.kt
+++ b/app/src/main/java/com/ishzk/android/recieptchart/fragment/HouseholdFragment.kt
@@ -212,7 +212,7 @@ class CardItemListViewHolder(private val binding: ItemEachDayCardBinding, privat
     fun bind(item: ItemsEachDay){
         binding.apply {
             val formatter = SimpleDateFormat("yyyy/MM/dd", Locale.JAPAN)
-            cardItemDate.text = formatter.format(item.day.toDate())
+            cardItemDate.text = formatter.format(item.day)
             totalEachDay.text = item.item.sumOf { it.cost }.toString()
             eachDayItemList.apply {
                 adapter = listAdapter

--- a/app/src/main/java/com/ishzk/android/recieptchart/model/FetchMonthlyHouseholdsEachDayUseCase.kt
+++ b/app/src/main/java/com/ishzk/android/recieptchart/model/FetchMonthlyHouseholdsEachDayUseCase.kt
@@ -1,6 +1,5 @@
 package com.ishzk.android.recieptchart.model
 
-import com.google.firebase.Timestamp
 import com.ishzk.android.recieptchart.viewmodel.*
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -9,14 +8,14 @@ import java.util.*
 class FetchMonthlyHouseholdsEachDayUseCase {
     lateinit var repository: HouseholdRepository
 
-    suspend operator fun invoke(userID: String, date: Date): Map<Timestamp, List<Household>> = withContext(Dispatchers.Default) {
+    suspend operator fun invoke(userID: String, date: Date): Map<Date, List<Household>> = withContext(Dispatchers.Default) {
         val items = repository.fetchPeriodicItems(
             userID,
             date.beginDayOfMonth(),
             date.endDayOfMonth().endDay()
         )
 
-        items.groupBy { it.date }
+        items.groupBy { it.date.toDate().beginDay() }
     }
 }
 

--- a/app/src/main/java/com/ishzk/android/recieptchart/viewmodel/HouseholdViewModel.kt
+++ b/app/src/main/java/com/ishzk/android/recieptchart/viewmodel/HouseholdViewModel.kt
@@ -1,10 +1,8 @@
 package com.ishzk.android.recieptchart.viewmodel
 
-import android.app.LauncherActivity
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.google.firebase.Timestamp
 import com.ishzk.android.recieptchart.model.FetchMonthlyHouseholdsEachDayUseCase
 import com.ishzk.android.recieptchart.model.Household
 import com.ishzk.android.recieptchart.model.HouseholdRepository
@@ -99,6 +97,6 @@ fun Date.beginDay(): Date = Date(year, month, date, 0, 0)
 fun Date.endDay(): Date = Date(year, month, date, 23, 59)
 
 data class ItemsEachDay(
-    val day: Timestamp,
+    val day: Date,
     val item: List<Household>,
 )


### PR DESCRIPTION
時間も含めて日付の比較を行っていたため、同じ日付でも時間が異なると別のカードに表示されていた。
#54 